### PR TITLE
chore: Fix build failures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,8 @@ Imports:
 Suggests: 
     covr,
     DBItest
+Remotes:
+    r-dbi/DBI
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1

--- a/man/DBI.Rd
+++ b/man/DBI.Rd
@@ -158,7 +158,17 @@
 
 \S4method{dbSendStatement}{adbcConnection,character}(conn, statement, ...)
 
-\S4method{dbWriteTable}{adbcConnection,character,data.frame}(conn, name, value, overwrite = FALSE, append = FALSE, ...)
+\S4method{dbWriteTable}{adbcConnection,character,data.frame}(
+  conn,
+  name,
+  value,
+  overwrite = FALSE,
+  append = FALSE,
+  ...,
+  field.types = NULL,
+  row.names = NULL,
+  temporary = FALSE
+)
 
 \S4method{show}{adbcConnection}(object)
 

--- a/man/adbc.Rd
+++ b/man/adbc.Rd
@@ -4,7 +4,13 @@
 \alias{adbc}
 \title{adbc driver}
 \usage{
-adbc()
+adbc(path, entrypoint = NULL)
+}
+\arguments{
+\item{path}{Path to the shared library}
+
+\item{entrypoint}{The name of the ADBC entry point,
+by default \code{"AdbcDriverInit"} is used.}
 }
 \description{
 TBD.


### PR DESCRIPTION
@krlmlr This is still going to fail because the tests don't run successfully.

It's because the tests can't find the local path `"/Users/kirill/git/R/duckdb/tools/rpkg/src/duckdb.so"`:

```
── Test failures ──────────────────────────── testthat ────

> library("testthat")
> 
> test_check("adbc")
Loading required package: adbc
Error in normalizePath(path, mustWork = TRUE) : 
  path[1]="/Users/kirill/git/R/duckdb/tools/rpkg/src/duckdb.so": No such file or directory
Calls: test_check ... <Anonymous> -> adbc -> load_driver -> normalizePath
Execution halted
```